### PR TITLE
Switch to using new partials plugin. Fixes #11.

### DIFF
--- a/metalsmith.js
+++ b/metalsmith.js
@@ -1,6 +1,7 @@
 var Metalsmith = require('metalsmith');
 var changed    = require('metalsmith-changed');
 var templates  = require('metalsmith-templates');
+var partials   = require('metalsmith-register-partials');
 var Handlebars = require('handlebars');
 var markdown   = require('metalsmith-markdown')
 var prismic    = require('metalsmith-prismic');
@@ -22,13 +23,6 @@ Handlebars.registerHelper("debug", function(optionalValue) {
     console.log("====================");
     console.log(optionalValue);
   }
-});
-
-// Register all partials in "./templates/partials".
-fs.readdirSync('templates/partials').forEach(function(file) {
-  var name = file.split(".")[0];
-  var contents = fs.readFileSync(__dirname + "/templates/partials/" + file).toString();
-  Handlebars.registerPartial(name, contents);
 });
 
 // If there's a prismic config use it.
@@ -64,6 +58,9 @@ module.exports = function metalSmith(done) {
     .use(prismicTask)
     .use(markdown())
     .use(webpack(webpackConfig))
+    .use(partials({
+      directory: 'templates/partials'
+    }))
     .use(templates('handlebars'))
     .use(sass({
       outputDir: 'css/'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "metalsmith-markdown": "^0.2.1",
     "metalsmith-permalinks": "^0.4.0",
     "metalsmith-prismic": "^0.7.1",
+    "metalsmith-register-partials": "^1.0.2",
     "metalsmith-sass": "^0.7.0",
     "metalsmith-templates": "^0.6.0",
     "metalsmith-webpack": "^1.0.1",


### PR DESCRIPTION
The problem here appeared to be that the partials were being registered outside of the exported Metalsmith function (which we were using inside of our build/watch tasks).

Moving the partial registration stuff inside there worked - however I also found a new plugin that basically does the same thing as our custom little bit of code to register partials and thought it might be nicer to use that since it just exposes a simpler API.